### PR TITLE
[BLUE-6]: Add `hideWhenZero` prop to `NumberFlow` component

### DIFF
--- a/src/components/tables/BorrowTable.tsx
+++ b/src/components/tables/BorrowTable.tsx
@@ -69,7 +69,7 @@ export const columns: ColumnDef<MarketSummary & { userBorrowUsd: number; userLtv
     accessorKey: "userBorrowUsd",
     header: "Your Borrow",
     cell: ({ row }) => {
-      return <NumberFlow value={row.original.userBorrowUsd} format={{ currency: "USD" }} />;
+      return <NumberFlow value={row.original.userBorrowUsd} format={{ currency: "USD" }} hideWhenZero />;
     },
     minSize: 160,
   },
@@ -80,8 +80,12 @@ export const columns: ColumnDef<MarketSummary & { userBorrowUsd: number; userLtv
       const market = row.original;
       return (
         <span className="flex items-center gap-1">
-          <NumberFlow value={row.original.userLtv} format={{ style: "percent", minimumFractionDigits: 1 }} /> /{" "}
-          {formatNumber(market.lltv, { style: "percent", minimumFractionDigits: 1 })}
+          <NumberFlow
+            value={row.original.userLtv}
+            format={{ style: "percent", minimumFractionDigits: 1 }}
+            hideWhenZero
+          />{" "}
+          / {formatNumber(market.lltv, { style: "percent", minimumFractionDigits: 1 })}
         </span>
       );
     },

--- a/src/components/tables/EarnTable.tsx
+++ b/src/components/tables/EarnTable.tsx
@@ -29,7 +29,7 @@ export const columns: ColumnDef<VaultSummary & { userDepositsUsd: number }>[] = 
     accessorKey: "userDepositsUsd",
     header: "Your Deposits",
     cell: ({ row }) => {
-      return <NumberFlow value={row.original.userDepositsUsd} format={{ currency: "USD" }} />;
+      return <NumberFlow value={row.original.userDepositsUsd} format={{ currency: "USD" }} hideWhenZero />;
     },
     minSize: 160,
   },

--- a/src/components/ui/NumberFlow.tsx
+++ b/src/components/ui/NumberFlow.tsx
@@ -4,12 +4,12 @@ import { ComponentProps } from "react";
 
 const MAX_USD_VALUE = 1e12;
 
-export default function NumberFlow({
-  value,
-  format,
-  className,
-  ...props
-}: { value: number } & ComponentProps<typeof NumberFlowReact>) {
+type NumberFlowProps = {
+  hideWhenZero?: boolean;
+  value: number;
+} & ComponentProps<typeof NumberFlowReact>;
+
+export default function NumberFlow({ className, format, hideWhenZero = false, value, ...props }: NumberFlowProps) {
   const currency = format?.currency;
   const isPercent = format?.style === "percent";
   const {
@@ -41,7 +41,9 @@ export default function NumberFlow({
     value = minValue * Math.pow(10, format?.style === "percent" ? -2 : 0) * (neg ? -1 : 1);
   }
 
-  return (
+  return hideWhenZero && value == 0 ? (
+    <span className={cn("text-content-secondary", className)}>-</span>
+  ) : (
     <span className={cn("inline-flex items-center", className)}>
       {prefix}
       <NumberFlowReact value={value} format={formatOptions} {...props} className="inline-flex items-center" />


### PR DESCRIPTION
When the `hideWhenZero` prop is `true`, it will replace the component with a "-" character instead when `value` is zero.