### PR TITLE
[BLUE-9] Update Key Metrics sections to use customized tooltips

### DIFF
--- a/src/app/(earn)/[vaultAddress]/page.tsx
+++ b/src/app/(earn)/[vaultAddress]/page.tsx
@@ -1,7 +1,7 @@
 import Apy, { ApyTooltipContent } from "@/components/Apy";
 import { LinkExternalBlockExplorer } from "@/components/LinkExternal";
 import MarketAllocationTable from "@/components/tables/MarketAllocationTable";
-import Metric, { Metric as MetricComponent } from "@/components/Metric";
+import { Metric, MetricWithTooltip } from "@/components/Metric";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton, Skeletons } from "@/components/ui/skeleton";
 import { getVault } from "@/data/whisk/getVault";
@@ -193,7 +193,7 @@ async function VaultState({ vaultAddress }: { vaultAddress: Address }) {
         <div key={i} className="flex-1">
           <TooltipPopover>
             <TooltipPopoverTrigger>
-              <MetricComponent label={metric.label}>{metric.value}</MetricComponent>
+              <Metric label={metric.label}>{metric.value}</Metric>
             </TooltipPopoverTrigger>
             <TooltipPopoverContent>{metric.tooltip}</TooltipPopoverContent>
           </TooltipPopover>
@@ -260,9 +260,9 @@ async function VaultInfo({ vaultAddress }: { vaultAddress: Address }) {
   return (
     <div className="grid grid-cols-1 gap-y-8 md:grid-cols-3 md:gap-y-10">
       {metrics.map((metric, i) => (
-        <Metric key={i} label={metric.label} description={metric.description}>
+        <MetricWithTooltip key={i} label={metric.label} tooltip={metric.description}>
           <span className="title-5">{metric.value}</span>
-        </Metric>
+        </MetricWithTooltip>
       ))}
     </div>
   );

--- a/src/app/(earn)/[vaultAddress]/page.tsx
+++ b/src/app/(earn)/[vaultAddress]/page.tsx
@@ -1,7 +1,7 @@
-import Apy from "@/components/Apy";
+import Apy, { ApyTooltipContent } from "@/components/Apy";
 import { LinkExternalBlockExplorer } from "@/components/LinkExternal";
 import MarketAllocationTable from "@/components/tables/MarketAllocationTable";
-import Metric from "@/components/Metric";
+import Metric, { Metric as MetricComponent } from "@/components/Metric";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton, Skeletons } from "@/components/ui/skeleton";
 import { getVault } from "@/data/whisk/getVault";
@@ -19,6 +19,7 @@ import BackButton from "@/components/BackButton";
 import { AccountVaultPosition, AccountVaultPositionHighlight } from "@/components/AccountVaultPosition";
 import NumberFlow from "@/components/ui/NumberFlow";
 import RiskTier from "@/components/RiskTier";
+import { TooltipPopover, TooltipPopoverContent, TooltipPopoverTrigger } from "@/components/ui/tooltipPopover";
 
 export const metadata: Metadata = {
   title: "Compound Blue | Vault",
@@ -168,30 +169,35 @@ async function VaultState({ vaultAddress }: { vaultAddress: Address }) {
     return null;
   }
 
-  const metrics: { label: string; description: string; value: ReactNode }[] = [
+  const metrics: { label: string; tooltip: ReactNode; value: ReactNode }[] = [
     {
       label: "Total Deposits",
-      description: "The total amount of assets currently deposited into the vault.",
-      value: <NumberFlow value={vault.supplyAssetsUsd} format={{ currency: "USD" }} />,
+      tooltip: "The total amount of assets currently deposited into the vault.",
+      value: <NumberFlow className="title-3" value={vault.supplyAssetsUsd} format={{ currency: "USD" }} />,
     },
     {
       label: "Available Liquidity",
-      description: "The available assets that can be withdrawn or reallocated.",
-      value: <NumberFlow value={vault.liquidityAssetsUsd} format={{ currency: "USD" }} />,
+      tooltip: "The available assets that can be withdrawn or reallocated.",
+      value: <NumberFlow className="title-3" value={vault.liquidityAssetsUsd} format={{ currency: "USD" }} />,
     },
     {
       label: "APY",
-      description: "The annual percent yield (APY) earned by depositing into this vault, including rewards and fees.",
-      value: <Apy type="supply" apy={vault.supplyApy} />,
+      tooltip: <ApyTooltipContent type="supply" apy={vault.supplyApy} />,
+      value: <Apy className="title-3" type="supply" apy={vault.supplyApy} showTooltip={false} />,
     },
   ];
 
   return (
     <div className="flex flex-wrap justify-between gap-x-8 gap-y-4">
       {metrics.map((metric, i) => (
-        <Metric key={i} label={metric.label} description={metric.description} className="flex-1">
-          <span className="title-3">{metric.value}</span>
-        </Metric>
+        <div key={i} className="flex-1">
+          <TooltipPopover>
+            <TooltipPopoverTrigger>
+              <MetricComponent label={metric.label}>{metric.value}</MetricComponent>
+            </TooltipPopoverTrigger>
+            <TooltipPopoverContent>{metric.tooltip}</TooltipPopoverContent>
+          </TooltipPopover>
+        </div>
       ))}
     </div>
   );

--- a/src/app/borrow/[marketId]/page.tsx
+++ b/src/app/borrow/[marketId]/page.tsx
@@ -7,7 +7,7 @@ import { Skeleton, Skeletons } from "@/components/ui/skeleton";
 import { formatNumber } from "@/utils/format";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import Apy, { ApyTooltipContent } from "@/components/Apy";
-import Metric, { Metric as MetricComponent } from "@/components/Metric";
+import { Metric, MetricWithTooltip } from "@/components/Metric";
 import VaultAllocationTable from "@/components/tables/VaultAllocationTable";
 import { LinkExternalBlockExplorer } from "@/components/LinkExternal";
 import Image from "next/image";
@@ -229,7 +229,7 @@ async function MarketState({ marketId }: { marketId: Hex }) {
         <div key={i} className="flex-1">
           <TooltipPopover>
             <TooltipPopoverTrigger>
-              <MetricComponent label={metric.label}>{metric.value}</MetricComponent>
+              <Metric label={metric.label}>{metric.value}</Metric>
             </TooltipPopoverTrigger>
             <TooltipPopoverContent>{metric.tooltip}</TooltipPopoverContent>
           </TooltipPopover>
@@ -278,9 +278,9 @@ async function MarketIrm({ marketId }: { marketId: Hex }) {
     <div className="flex flex-col justify-between gap-8 lg:flex-row">
       <div className="flex flex-col justify-between gap-6 md:flex-row lg:flex-col">
         {metrics.map((metric, i) => (
-          <Metric key={i} label={metric.label} description={metric.description} className="flex-1">
+          <MetricWithTooltip key={i} label={metric.label} tooltip={metric.description} className="flex-1">
             <span className="title-5">{metric.value}</span>
-          </Metric>
+          </MetricWithTooltip>
         ))}
       </div>
       {market.irm.curve && <IrmChart data={market.irm.curve} currentUtilization={market.utilization} />}
@@ -360,9 +360,9 @@ async function MarketInfo({ marketId }: { marketId: Hex }) {
   return (
     <div className="grid grid-cols-1 gap-y-8 md:grid-cols-3 md:gap-y-10">
       {metrics.map((metric, i) => (
-        <Metric key={i} label={metric.label} description={metric.description}>
+        <MetricWithTooltip key={i} label={metric.label} tooltip={metric.description}>
           <span className="title-5">{metric.value}</span>
-        </Metric>
+        </MetricWithTooltip>
       ))}
     </div>
   );

--- a/src/app/borrow/[marketId]/page.tsx
+++ b/src/app/borrow/[marketId]/page.tsx
@@ -6,8 +6,8 @@ import { ReactNode, Suspense } from "react";
 import { Skeleton, Skeletons } from "@/components/ui/skeleton";
 import { formatNumber } from "@/utils/format";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import Apy from "@/components/Apy";
-import Metric from "@/components/Metric";
+import Apy, { ApyTooltipContent } from "@/components/Apy";
+import Metric, { Metric as MetricComponent } from "@/components/Metric";
 import VaultAllocationTable from "@/components/tables/VaultAllocationTable";
 import { LinkExternalBlockExplorer } from "@/components/LinkExternal";
 import Image from "next/image";
@@ -18,7 +18,7 @@ import { notFound } from "next/navigation";
 import { WHITELISTED_MARKET_IDS } from "@/config";
 import BackButton from "@/components/BackButton";
 import { AccountMarketPosition, AccountMarketPositionHighlight } from "@/components/AccountMarketPosition";
-import MarketAvailableLiquidity from "@/components/MarketAvailableLiquidity";
+import MarketAvailableLiquidity, { MarketAvailableLiquidityTooltip } from "@/components/MarketAvailableLiquidity";
 import NumberFlow from "@/components/ui/NumberFlow";
 import { MarketIcon } from "@/components/MarketIdentifier";
 import { TooltipPopover, TooltipPopoverTrigger, TooltipPopoverContent } from "@/components/ui/tooltipPopover";
@@ -193,36 +193,47 @@ async function MarketState({ marketId }: { marketId: Hex }) {
     return null;
   }
 
-  const metrics: { label: string; description: string; value: ReactNode }[] = [
+  const metrics: { label: string; tooltip: ReactNode; value: ReactNode }[] = [
     {
       label: "Total Deposits",
-      description: "The total amount of assets currently deposited into the market.",
-      value: <NumberFlow value={market.supplyAssetsUsd} format={{ currency: "USD" }} />,
+      tooltip: "The total amount of assets currently deposited into the market.",
+      value: <NumberFlow className="title-3" value={market.supplyAssetsUsd} format={{ currency: "USD" }} />,
     },
     {
       label: "Available Liquidity",
-      description:
-        "The total amount of assets available for borrowing, including liquidity that can be reallocated from other markets through the public allocator.",
-      value: (
-        <MarketAvailableLiquidity
+      tooltip: (
+        <MarketAvailableLiquidityTooltip
           liquidityAssetUsd={market.liquidityAssetsUsd}
           publicAllocatorSharedLiquidityAssetsUsd={market.publicAllocatorSharedLiquidityAssetsUsd}
+        />
+      ),
+      value: (
+        <MarketAvailableLiquidity
+          className="title-3"
+          liquidityAssetUsd={market.liquidityAssetsUsd}
+          publicAllocatorSharedLiquidityAssetsUsd={market.publicAllocatorSharedLiquidityAssetsUsd}
+          showTooltip={false}
         />
       ),
     },
     {
       label: "Borrow APY",
-      description: "The annual percent yield (APY) payed for borrowing from this market, including rewards.",
-      value: <Apy type="borrow" apy={market.borrowApy} />,
+      tooltip: <ApyTooltipContent apy={market.borrowApy} type="borrow" />,
+      value: <Apy className="title-3" type="borrow" apy={market.borrowApy} showTooltip={false} />,
     },
   ];
 
   return (
     <div className="flex flex-wrap justify-between gap-x-8 gap-y-4">
       {metrics.map((metric, i) => (
-        <Metric key={i} label={metric.label} description={metric.description} className="flex-1">
-          <span className="title-3">{metric.value}</span>
-        </Metric>
+        <div key={i} className="flex-1">
+          <TooltipPopover>
+            <TooltipPopoverTrigger>
+              <MetricComponent label={metric.label}>{metric.value}</MetricComponent>
+            </TooltipPopoverTrigger>
+            <TooltipPopoverContent>{metric.tooltip}</TooltipPopoverContent>
+          </TooltipPopover>
+        </div>
       ))}
     </div>
   );

--- a/src/components/AccountMarketPosition.tsx
+++ b/src/components/AccountMarketPosition.tsx
@@ -3,7 +3,7 @@ import { descaleBigIntToNumber, formatNumber } from "@/utils/format";
 import { Hex } from "viem";
 import { ReactNode } from "react";
 import { Skeleton } from "./ui/skeleton";
-import Metric from "./Metric";
+import { MetricWithTooltip } from "./Metric";
 import { useAccount } from "wagmi";
 import Image from "next/image";
 import NumberFlow, { NumberFlowWithLoading } from "./ui/NumberFlow";
@@ -87,13 +87,13 @@ export function AccountMarketPositionHighlight({ market }: MarketPositionProps) 
 
   return (
     <div className="flex flex-col md:items-end md:text-end">
-      <Metric
+      <MetricWithTooltip
         label={<span className="justify-end text-accent-ternary">Borrowing</span>}
-        description="Your borrow balance in this market."
+        tooltip="Your borrow balance in this market."
         className="title-3 md:items-end"
       >
         <NumberFlow value={marketPosition.borrowAssetsUsd} format={{ currency: "USD" }} />
-      </Metric>
+      </MetricWithTooltip>
       <div className="flex items-center gap-1 text-content-secondary label-sm">
         {market.loanAsset.icon && (
           <Image
@@ -114,9 +114,9 @@ export function AccountMarketPositionAggregate() {
   const { data: accountMarketPositonAggregate, isLoading } = useAccountMarketPositionAggregate();
   return (
     <div className="flex gap-10 md:text-end">
-      <Metric
+      <MetricWithTooltip
         label={<span className="justify-end text-accent-ternary">Your Borrowing</span>}
-        description="Your total borrow balance across all markets."
+        tooltip="Your total borrow balance across all markets."
         className="title-3 md:items-end"
       >
         <NumberFlowWithLoading
@@ -125,11 +125,11 @@ export function AccountMarketPositionAggregate() {
           isLoading={isLoading}
           loadingContent={<Skeleton className="h-[36px] w-[70px]" />}
         />
-      </Metric>
+      </MetricWithTooltip>
 
-      <Metric
+      <MetricWithTooltip
         label={<span className="justify-end">Avg. Borrow APY</span>}
-        description="Your average borrow APY across all markets, including rewards."
+        tooltip="Your average borrow APY across all markets, including rewards."
         className="title-3 md:items-end"
       >
         <NumberFlowWithLoading
@@ -138,7 +138,7 @@ export function AccountMarketPositionAggregate() {
           isLoading={isLoading}
           loadingContent={<Skeleton className="h-[36px] w-[70px]" />}
         />
-      </Metric>
+      </MetricWithTooltip>
     </div>
   );
 }

--- a/src/components/AccountVaultPosition.tsx
+++ b/src/components/AccountVaultPosition.tsx
@@ -3,7 +3,7 @@ import { descaleBigIntToNumber } from "@/utils/format";
 import { getAddress } from "viem";
 import { ReactNode } from "react";
 import { Skeleton } from "./ui/skeleton";
-import Metric from "./Metric";
+import { MetricWithTooltip } from "./Metric";
 import { useAccount } from "wagmi";
 import Image from "next/image";
 import NumberFlow, { NumberFlowWithLoading } from "./ui/NumberFlow";
@@ -58,13 +58,13 @@ export function AccountVaultPositionHighlight({ vault }: { vault: Vault }) {
 
   return (
     <div className="flex flex-col md:items-end md:text-end">
-      <Metric
+      <MetricWithTooltip
         label={<span className="justify-end text-accent-secondary">Supplying</span>}
-        description="Your supply balance in this vault."
+        tooltip="Your supply balance in this vault."
         className="title-3 md:items-end"
       >
         <NumberFlow value={vaultPosition.supplyAssetsUsd} format={{ currency: "USD" }} />
-      </Metric>
+      </MetricWithTooltip>
       <div className="flex items-center gap-1 text-content-secondary label-sm">
         {vault.asset.icon && (
           <Image src={vault.asset.icon} width={12} height={12} alt={vault.asset.symbol} className="rounded-full" />
@@ -82,9 +82,9 @@ export function AccountVaultPositionAggregate() {
   const { data: accountVaultPositionAggregate, isLoading } = useAccountVaultPositionAggregate();
   return (
     <div className="flex gap-10 md:text-end">
-      <Metric
+      <MetricWithTooltip
         label={<span className="justify-end text-accent-secondary">Your Deposits</span>}
-        description="Your total deposit balance across all vaults."
+        tooltip="Your total deposit balance across all vaults."
         className="title-3 md:items-end"
       >
         <NumberFlowWithLoading
@@ -93,11 +93,11 @@ export function AccountVaultPositionAggregate() {
           isLoading={isLoading}
           loadingContent={<Skeleton className="h-[36px] w-[70px]" />}
         />
-      </Metric>
+      </MetricWithTooltip>
 
-      <Metric
+      <MetricWithTooltip
         label={<span className="justify-end">Avg. Earn APY</span>}
-        description="Your average supply APY across all vaults, including rewards and fees."
+        tooltip="Your average supply APY across all vaults, including rewards and fees."
         className="title-3 md:items-end"
       >
         <NumberFlowWithLoading
@@ -106,7 +106,7 @@ export function AccountVaultPositionAggregate() {
           isLoading={isLoading}
           loadingContent={<Skeleton className="h-[36px] w-[70px]" />}
         />
-      </Metric>
+      </MetricWithTooltip>
     </div>
   );
 }

--- a/src/components/MarketAvailableLiquidity.tsx
+++ b/src/components/MarketAvailableLiquidity.tsx
@@ -1,22 +1,62 @@
 import { formatNumber } from "@/utils/format";
 import { TooltipPopover, TooltipPopoverContent, TooltipPopoverTrigger } from "./ui/tooltipPopover";
 import NumberFlow from "./ui/NumberFlow";
+import { ComponentProps } from "react";
 
-interface MarketAvailableLiquidityProps {
+type MarketAvailableLiquidityProps = {
   liquidityAssetUsd: number;
   publicAllocatorSharedLiquidityAssetsUsd: number;
-}
+  showTooltip?: boolean;
+} & React.ComponentProps<"div">;
+
+type MarketAvailableLiquidityItem = {
+  label: string;
+  value: string;
+};
+
+type MarketAvailableLiquidityTooltipProps = {
+  liquidityAssetUsd: number;
+  publicAllocatorSharedLiquidityAssetsUsd: number;
+};
+
+type MarketAvailableLiquidityTriggerProps = {
+  total: number;
+} & ComponentProps<typeof NumberFlow>;
 
 export default function MarketAvailableLiquidity({
+  className,
   liquidityAssetUsd,
   publicAllocatorSharedLiquidityAssetsUsd,
+  showTooltip = true,
 }: MarketAvailableLiquidityProps) {
   const total = liquidityAssetUsd + publicAllocatorSharedLiquidityAssetsUsd;
 
-  const items: {
-    label: string;
-    value: string;
-  }[] = [
+  return showTooltip ? (
+    <TooltipPopover>
+      <TooltipPopoverTrigger>
+        <MarketAvailableLiquidityTrigger className={className} total={total} />
+      </TooltipPopoverTrigger>
+      <TooltipPopoverContent className="w-[320px]">
+        <MarketAvailableLiquidityTooltip
+          liquidityAssetUsd={liquidityAssetUsd}
+          publicAllocatorSharedLiquidityAssetsUsd={publicAllocatorSharedLiquidityAssetsUsd}
+        />
+      </TooltipPopoverContent>
+    </TooltipPopover>
+  ) : (
+    <MarketAvailableLiquidityTrigger className={className} total={total} />
+  );
+}
+
+function MarketAvailableLiquidityTrigger({ total, ...props }: MarketAvailableLiquidityTriggerProps) {
+  return <NumberFlow value={total} format={{ currency: "USD" }} {...props} />;
+}
+
+export function MarketAvailableLiquidityTooltip({
+  liquidityAssetUsd,
+  publicAllocatorSharedLiquidityAssetsUsd,
+}: MarketAvailableLiquidityTooltipProps) {
+  const items: MarketAvailableLiquidityItem[] = [
     {
       label: "Liquidity in Market",
       value: formatNumber(liquidityAssetUsd, { currency: "USD" }),
@@ -27,31 +67,28 @@ export default function MarketAvailableLiquidity({
     },
   ];
 
+  const total = liquidityAssetUsd + publicAllocatorSharedLiquidityAssetsUsd;
+
   return (
-    <TooltipPopover>
-      <TooltipPopoverTrigger>
-        <NumberFlow value={total} format={{ currency: "USD" }} />
-      </TooltipPopoverTrigger>
-      <TooltipPopoverContent className="flex w-[320px] flex-col gap-4">
-        <span className="label-md">Market Liquidity</span>
-        <p className="text-content-secondary paragraph-sm">
-          The total amount of assets available for borrowing, including liquidity that can be reallocated from other
-          markets through the public allocator.
-        </p>
-        <div className="flex flex-col gap-2 paragraph-sm">
-          {items.map((item, i) => (
-            <div className="flex items-center justify-between" key={i}>
-              <span>{item.label}</span>
-              <span className="label-sm">{item.value}</span>
-            </div>
-          ))}
-        </div>
-        <div className="h-[1px] w-full bg-border-primary" />
-        <div className="flex items-center justify-between label-md">
-          <span>Total Available Liquidity</span>
-          <span>{formatNumber(total, { currency: "USD" })}</span>
-        </div>
-      </TooltipPopoverContent>
-    </TooltipPopover>
+    <div className="flex flex-col gap-4">
+      <span className="label-md">Market Liquidity</span>
+      <p className="text-content-secondary paragraph-sm">
+        The total amount of assets available for borrowing, including liquidity that can be reallocated from other
+        markets through the public allocator.
+      </p>
+      <div className="flex flex-col gap-2 paragraph-sm">
+        {items.map((item, i) => (
+          <div className="flex items-center justify-between" key={i}>
+            <span>{item.label}</span>
+            <span className="label-sm">{item.value}</span>
+          </div>
+        ))}
+      </div>
+      <div className="h-[1px] w-full bg-border-primary" />
+      <div className="flex items-center justify-between label-md">
+        <span>Total Available Liquidity</span>
+        <span>{formatNumber(total, { currency: "USD" })}</span>
+      </div>
+    </div>
   );
 }

--- a/src/components/Metric.tsx
+++ b/src/components/Metric.tsx
@@ -1,22 +1,41 @@
 import { cn } from "@/utils/shadcn";
-import { HTMLAttributes, ReactNode } from "react";
+import { ReactNode } from "react";
 import { TooltipPopover, TooltipPopoverTrigger, TooltipPopoverContent } from "./ui/tooltipPopover";
 
-export interface MetricProps extends HTMLAttributes<HTMLDivElement> {
+export type MetricProps = {
   label: ReactNode;
-  description: string;
   children: ReactNode;
-}
+} & React.ComponentProps<"div">;
 
-export default function Metric({ label, description, children, className, ...props }: MetricProps) {
+export type MetricWithTooltipProps = {
+  description: string;
+} & MetricProps;
+
+export default function MetricWithTooltip({
+  label,
+  children,
+  description,
+  className,
+  ...props
+}: MetricWithTooltipProps) {
   return (
     <div className={cn("flex flex-col gap-1", className)} {...props}>
       <TooltipPopover>
-        <TooltipPopoverTrigger className="label-md w-fit whitespace-nowrap text-content-secondary">
-          {label}
+        <TooltipPopoverTrigger>
+          <Metric label={label} className={className}>
+            {children}
+          </Metric>
         </TooltipPopoverTrigger>
         <TooltipPopoverContent>{description}</TooltipPopoverContent>
       </TooltipPopover>
+    </div>
+  );
+}
+
+export function Metric({ label, children, className, ...props }: MetricProps) {
+  return (
+    <div className={cn("flex flex-col gap-1 text-left text-content-primary", className)} {...props}>
+      <p className="w-fit whitespace-nowrap text-content-secondary label-md">{label}</p>
       {children}
     </div>
   );

--- a/src/components/Metric.tsx
+++ b/src/components/Metric.tsx
@@ -8,16 +8,10 @@ export type MetricProps = {
 } & React.ComponentProps<"div">;
 
 export type MetricWithTooltipProps = {
-  description: string;
+  tooltip: ReactNode;
 } & MetricProps;
 
-export default function MetricWithTooltip({
-  label,
-  children,
-  description,
-  className,
-  ...props
-}: MetricWithTooltipProps) {
+export function MetricWithTooltip({ label, children, tooltip, className, ...props }: MetricWithTooltipProps) {
   return (
     <div className={cn("flex flex-col gap-1", className)} {...props}>
       <TooltipPopover>
@@ -26,7 +20,7 @@ export default function MetricWithTooltip({
             {children}
           </Metric>
         </TooltipPopoverTrigger>
-        <TooltipPopoverContent>{description}</TooltipPopoverContent>
+        <TooltipPopoverContent>{tooltip}</TooltipPopoverContent>
       </TooltipPopover>
     </div>
   );


### PR DESCRIPTION
- Updates the `Metric` component to use the tooltip version by default, but also export a non-tooltip version as well.
- Adds `showTooltip` prop to `Apy` and `MarketAvailableLiquidity` components. When `false`, the component will not render any tooltip and just component inside the trigger.
- Exported tooltip content for `Apy` and `MarketAvailableLiquidity` as components
- Updated Earn and Borrow pages to use the tooltip components from `Apy` and `MarketAvailableLiquidity` for a customized trigger