### PR TITLE
[BLUE-15] Various VQA fixes

### DIFF
--- a/src/app/(earn)/[vaultAddress]/page.tsx
+++ b/src/app/(earn)/[vaultAddress]/page.tsx
@@ -194,7 +194,9 @@ async function VaultState({ vaultAddress }: { vaultAddress: Address }) {
         <div key={i} className="flex-1">
           <TooltipPopover>
             <TooltipPopoverTrigger>
-              <Metric label={metric.label}>{metric.value}</Metric>
+              <Metric label={metric.label} className="gap-1">
+                {metric.value}
+              </Metric>
             </TooltipPopoverTrigger>
             <TooltipPopoverContent>{metric.tooltip}</TooltipPopoverContent>
           </TooltipPopover>

--- a/src/app/borrow/[marketId]/page.tsx
+++ b/src/app/borrow/[marketId]/page.tsx
@@ -240,7 +240,9 @@ async function MarketState({ marketId }: { marketId: Hex }) {
         <div key={i} className="flex-1">
           <TooltipPopover>
             <TooltipPopoverTrigger>
-              <Metric label={metric.label}>{metric.value}</Metric>
+              <Metric label={metric.label} className="gap-1">
+                {metric.value}
+              </Metric>
             </TooltipPopoverTrigger>
             <TooltipPopoverContent>{metric.tooltip}</TooltipPopoverContent>
           </TooltipPopover>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,8 +33,9 @@
     --accent-ternary: 111 66 235;
 
     --button-supply: 0 194 137;
-    --button-supply-muted: 0 194 137;
+    --button-supply-deemphasized: 197 235 223;
     --button-borrow: 111 66 235;
+    --button-borrow-deemphasized: 218 204 255;
     --button-neutral: 216 223 229;
     --button-disabled: 240 242 245;
 
@@ -66,8 +67,9 @@
     --accent-ternary: 143 102 255;
 
     --button-supply: 0 173 121;
-    --button-supply-muted: 7 62 46;
+    --button-supply-deemphasized: 7 62 46;
     --button-borrow: 111 66 235;
+    --button-borrow-deemphasized: 59 40 112;
     --button-neutral: 43 57 71;
     --button-disabled: 23 33 43;
   }

--- a/src/components/ConnectWalletButton.tsx
+++ b/src/components/ConnectWalletButton.tsx
@@ -44,7 +44,11 @@ export default function ConnectWalletButton() {
               }
 
               return (
-                <Button onClick={openAccountModal} variant="secondary" className="aspect-square border p-0 md:px-4">
+                <Button
+                  onClick={openAccountModal}
+                  variant="secondary"
+                  className="aspect-square border p-0 md:aspect-auto md:px-4"
+                >
                   <span className="hidden md:block">{account.displayName}</span>
                   <Wallet className="block fill-content-primary md:hidden" />
                 </Button>

--- a/src/components/MarketActions/Borrow/MarketLeverageBorrow.tsx
+++ b/src/components/MarketActions/Borrow/MarketLeverageBorrow.tsx
@@ -279,7 +279,8 @@ export default function MarketLeverageBorrow({
               <div className="flex min-w-0 flex-col gap-2">
                 <Button
                   type="submit"
-                  className="w-full bg-accent-ternary"
+                  className="w-full"
+                  variant="borrow"
                   disabled={simulatingBundle || initialCollateralAmount == 0 || !form.formState.isValid}
                   isLoading={simulatingBundle}
                   loadingMessage="Simulating"

--- a/src/components/MarketActions/Borrow/MarketSupplyCollateralBorrow.tsx
+++ b/src/components/MarketActions/Borrow/MarketSupplyCollateralBorrow.tsx
@@ -208,7 +208,8 @@ export default function MarketSupplyCollateralBorrow({
               <div className="flex min-w-0 flex-col gap-2">
                 <Button
                   type="submit"
-                  className="w-full bg-accent-ternary"
+                  className="w-full"
+                  variant="borrow"
                   disabled={
                     simulatingBundle || (borrowAmount == 0 && supplyCollateralAmount == 0) || !form.formState.isValid
                   }

--- a/src/components/Metric.tsx
+++ b/src/components/Metric.tsx
@@ -15,7 +15,7 @@ export type MetricWithTooltipProps = {
 
 export function MetricWithTooltip({ label, children, tooltip, className, ...props }: MetricWithTooltipProps) {
   return (
-    <div className={cn("flex flex-col gap-1", className)} {...props}>
+    <div className={cn("flex flex-col gap-2", className)} {...props}>
       <TooltipPopover>
         <TooltipPopoverTrigger>
           <Metric label={label} className={className}>
@@ -30,7 +30,7 @@ export function MetricWithTooltip({ label, children, tooltip, className, ...prop
 
 export function Metric({ label, children, className, ...props }: MetricProps) {
   return (
-    <div className={cn("flex flex-col gap-1 text-left text-content-primary", className)} {...props}>
+    <div className={cn("flex flex-col gap-2 text-left text-content-primary", className)} {...props}>
       <p className="w-fit whitespace-nowrap text-content-secondary label-md">{label}</p>
       {children}
     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/utils/shadcn";
 const buttonVariants = cva(
   clsx(
     "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full transition-all",
+    "disabled:scale-1 active:scale-[.98]",
     "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-primary",
     "disabled:pointer-events-none disabled:opacity-50",
     "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
@@ -16,7 +17,10 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: "bg-button-supply hover:brightness-90 text-white",
+        primary:
+          "bg-button-supply hover:brightness-90 text-white active:bg-button-supply-deemphasized active:brightness-100",
+        borrow:
+          "bg-button-borrow hover:brightness-90 text-white active:bg-button-borrow-deemphasized active:brightness-100",
         secondary: "bg-button-neutral hover:brightness-90",
         negative: "bg-button-neutral text-semantic-negative hover:brightness-90",
         ghost: "hover:bg-button-neutral",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,8 +50,12 @@ export default {
           supply: {
             DEFAULT: "rgb(var(--button-supply))",
             muted: "rgb(var(--button-supply-muted))",
+            deemphasized: "rgb(var(--button-supply-deemphasized))",
           },
-          borrow: "rgb(var(--button-borrow))",
+          borrow: {
+            DEFAULT: "rgb(var(--button-borrow))",
+            deemphasized: "rgb(var(--button-borrow-deemphasized))",
+          },
           neutral: "rgb(var(--button-neutral))",
           disabled: "rgb(var(--button-disabled))",
         },


### PR DESCRIPTION
- Minor spacing fixes
- ~~Fix global layout so each section has the same width~~
- Fix header wallet button going outside of grid
- Add missing colors for supply and borrow
- Update default button styles (set default variant to supply, same as "primary", just clearer naming)
- Add active effect to button (scale 98%)
- ~~Removed a few unnecessary `div` wrappers~~
- ~~Update "powered by morpho" component to use `svg` instead of nextjs's `Image` (allows for changing the color via `fill` properties instead of requiring two separate images)~~