### PR TITLE
[N-02] Migration UI Allows Higher Slippage Than the Underlying Actions

### DIFF
--- a/src/components/ProtocolMigrator/ProtocolMigratorController.tsx
+++ b/src/components/ProtocolMigrator/ProtocolMigratorController.tsx
@@ -49,7 +49,10 @@ import { ProtocolMigratorWarningBanner } from "./ProtocolMigratorWarningBanner";
 
 const baseFields = {
   portfolioPercent: z.coerce.number().min(5, { message: "Minimum 5%" }).max(100, { message: "Maximum 100%" }),
-  maxSlippageTolerancePercent: z.coerce.number().min(0.2).max(100),
+  maxSlippageTolerancePercent: z.coerce
+    .number()
+    .min(0.2, { message: "Must be greater than or equal to 0.2%" })
+    .max(50, { message: "Must be less than or equal to 50%" }),
 };
 
 const protocolMigratorFormSchema = z.discriminatedUnion("destinationType", [


### PR DESCRIPTION
Addressed N-02 in OZ audit by clamping zod input validation for slippage to 50% (same as action limit), and adding better user facing error messages.

<img width="845" alt="Screenshot 2025-06-09 at 16 51 28" src="https://github.com/user-attachments/assets/de2ccc70-d625-4888-ba76-d19618aad962" />
